### PR TITLE
Keep a track of the current number of clients

### DIFF
--- a/src/executor/txmessage.rs
+++ b/src/executor/txmessage.rs
@@ -9,6 +9,7 @@ pub enum TXMessageKind {
 pub struct TXMessage {
     pub kind: TXMessageKind,
     pub tx_id: u16,
+    pub client_id: u32,
     pub tx_duration_us: u128,
     pub tx_timestamp: i64,
     pub error: String,
@@ -19,6 +20,7 @@ impl TXMessage {
         TXMessage {
             kind: TXMessageKind::DEFAULT,
             tx_id: 0,
+            client_id: 0,
             tx_duration_us: 0,
             tx_timestamp: 0,
             error: "".to_string(),
@@ -32,20 +34,22 @@ impl TXMessage {
         m
     }
 
-    pub fn error(tx_id: u16, tx_timestamp: i64, error: String) -> TXMessage {
+    pub fn error(tx_id: u16, client_id: u32, tx_timestamp: i64, error: String) -> TXMessage {
         let mut m = Self::default();
         m.kind = TXMessageKind::ERROR;
         m.tx_id = tx_id;
+        m.client_id = client_id;
         m.tx_timestamp = tx_timestamp;
         m.error = error;
 
         m
     }
 
-    pub fn committed(tx_id: u16, tx_timestamp: i64, tx_duration_us: u128) -> TXMessage {
+    pub fn committed(tx_id: u16, client_id: u32, tx_timestamp: i64, tx_duration_us: u128) -> TXMessage {
         let mut m = Self::default();
         m.kind = TXMessageKind::COMMITTED;
         m.tx_id = tx_id;
+        m.client_id = client_id;
         m.tx_timestamp = tx_timestamp;
         m.tx_duration_us = tx_duration_us;
 


### PR DESCRIPTION
We want to store in the log file how many clients were running when a transaction was executed.