### PR TITLE
Option --no-fkey to the init command

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -544,7 +544,12 @@ impl Executor {
     }
 
     // Execute foreign keys DDLs using multiple concurrent jobs
-    pub fn add_foreign_keys(&mut self, n_jobs: u32) -> &mut Self {
+    pub fn add_foreign_keys(&mut self, n_jobs: u32, no_fkey: bool) -> &mut Self {
+        // Don't do anything if no_fkey is true
+        if no_fkey {
+            return self;
+        }
+
         // Load the corresponding benchmark
         let benchmark = self.get_benchmark(0, 0, 0);
         let start = Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
                 .init_db_schema()
                 .load_data(env.init_args.scalefactor, env.init_args.jobs)
                 .add_primary_keys(env.init_args.jobs)
-                .add_foreign_keys(env.init_args.jobs)
+                .add_foreign_keys(env.init_args.jobs, env.init_args.no_fkey)
                 .add_indexes(env.init_args.jobs)
                 .vacuum(env.init_args.jobs)
                 .checkpoint();


### PR DESCRIPTION
When using this flag, database foreign keys are not created during the initialization stage.